### PR TITLE
Fix web library assembly detection

### DIFF
--- a/TixFactory.RepositoryParser/TixFactory.RepositoryParser/Implementation/Project.cs
+++ b/TixFactory.RepositoryParser/TixFactory.RepositoryParser/Implementation/Project.cs
@@ -232,6 +232,13 @@ namespace TixFactory.RepositoryParser
 			var sdkAttribute = ProjectContents?.Attributes().FirstOrDefault(a => _SdkAttributeName.Equals(a.Name.LocalName, StringComparison.OrdinalIgnoreCase));
 			if (_WebSdk.Equals(sdkAttribute?.Value, StringComparison.OrdinalIgnoreCase))
 			{
+				var isPackable = GetPropertyValue(_IsPackablePropertyName, raw: false);
+				var isPackableValue = "true";
+				if (isPackableValue.Equals(isPackable, StringComparison.OrdinalIgnoreCase))
+				{
+					return ProjectType.Assembly;
+				}
+
 				return ProjectType.WebApplication;
 			}
 


### PR DESCRIPTION
`Microsoft.NET.Sdk.Web` were being detected as web application assemblies, which makes sense, most assemblies using the `Microsoft.NET.Sdk.Web` SDK are web applications.
[TixFactory.Http.Service](https://github.com/tix-factory/nuget/blob/master/TixFactory.Http/TixFactory.Http.Service/TixFactory.Http.Service.csproj) is a library assembly using the `Microsoft.NET.Sdk.Web` SDK. To filter this as a library assembly instead of a web application we're going to check for the `IsPackable` project, using the assumption that web applications won't be packaged as NuGet packages.